### PR TITLE
fix an errata

### DIFF
--- a/ipynb/ex_MNIST_knn_classification.ipynb
+++ b/ipynb/ex_MNIST_knn_classification.ipynb
@@ -1,35 +1,20 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/tsakailab/prml/blob/master/ipynb/ex_MNIST_knn_classification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "UTNIg2oEn2n8"
       },
-      "cell_type": "markdown",
       "source": [
         "# MNIST手書き数字画像のk近傍識別（k-NN）\n",
         "$k$-nearest neighbors classification ($k$-NN) of the MNIST digits\n",
@@ -75,15 +60,20 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### データ集合を取得します．"
-      ],
       "metadata": {
         "id": "GKxBfkhj8QZj"
-      }
+      },
+      "source": [
+        "### データ集合を取得します．"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iFGaBeiY7wNq"
+      },
+      "outputs": [],
       "source": [
         "from torchvision import datasets\n",
         "\n",
@@ -102,15 +92,16 @@
         "#tvds = datasets.EMNIST('./data', download=True, train=True, split='letters')\n",
         "#Ximages_all, y_all = tvds.data.transpose_(-1,-2).numpy(), tvds.targets.numpy() - 1\n",
         "     "
-      ],
-      "metadata": {
-        "id": "iFGaBeiY7wNq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "L_22PEa08NBZ"
+      },
+      "outputs": [],
       "source": [
         "#@title ☆画像数とサイズを確認します（画像を加工したい場合はこのセルを編集して利用してください）．\n",
         "import numpy as np\n",
@@ -131,21 +122,18 @@
         "#height, width = 8, 8; Ximages = resize(np.float32(Ximages_all.transpose((1,2,0))), (height, width)).transpose(2,0,1)\n",
         "\n",
         "''' simulate noisy images '''\n",
-        "#Ximages = Ximages_all + np.random.rand(*Ximages_all.shape) * 200; Ximages_all[Ximages_all > 255] = 255\n",
+        "#Ximages = Ximages + np.random.rand(*Ximages.shape) * 200; Ximages = np.clip(Ximages,a_min=0,a_max=255)\n",
         "\n",
         "Ximages = np.uint8(Ximages)\n",
         "print(\"(#images, height, width)\", Ximages.shape)\n",
         "print(Ximages.dtype, \", max. pixel value = \", Ximages.max())"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "L_22PEa08NBZ"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "VFE1WbHu8U-U"
+      },
       "source": [
         "MNIST class labels\n",
         "\n",
@@ -153,34 +141,32 @@
         "| - | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\n",
         "| [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist) | **T-shirt/top** | Trouser | **Pullover** | Dress | **Coat** | Sandal |  **Shirt** | Sneaker | Bag | Ankle boot |\n",
         "| [Kuzushiji-MNIST](https://github.com/rois-codh/kmnist) | お | き | す | つ | な | は |  ま | や | れ | を |"
-      ],
-      "metadata": {
-        "id": "VFE1WbHu8U-U"
-      }
+      ]
     },
     {
-      "metadata": {
-        "id": "E7Ib1PU2n2oK",
-        "cellView": "form"
-      },
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "E7Ib1PU2n2oK"
+      },
+      "outputs": [],
       "source": [
         "#@title 画像を表示する関数 implot を定義し，画像を例示します．\n",
         "!wget -q -N https://gist.githubusercontent.com/tsakai-g/c54a8fa059f9c655290586ec1cc2ec7b/raw/f4d10dc70022dd7c160d4e40940b287863bd5258/implot.py\n",
+        "\n",
         "%run implot.py\n",
         "\n",
         "print(\"%d images in total\" % len(y))\n",
         "p = np.random.permutation(len(y))\n",
         "implot(Ximages[p], y[p], num=16, vmin=0, vmax=255)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "UQFrBwjAn2oS"
       },
-      "cell_type": "markdown",
       "source": [
         "### 実行と評価\n",
         "\n",
@@ -191,6 +177,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "arAOq-4QlcA-"
+      },
+      "outputs": [],
       "source": [
         "from sklearn import neighbors\n",
         "# https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html\n",
@@ -202,15 +193,16 @@
         "#clf = neighbors.KNeighborsClassifier(n_neighbors = k, metric='cosine')\n",
         "\n",
         "val_size = 1000"
-      ],
-      "metadata": {
-        "id": "arAOq-4QlcA-"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "K9nCZ5D6groz"
+      },
+      "outputs": [],
       "source": [
         "#@title 識別の実行と結果の例示\n",
         "\n",
@@ -238,20 +230,16 @@
         "# the number of correct matches / the total number of data points\n",
         "matches = (y_pred == y_val)\n",
         "print(\"Accuracy = %d / %d = %2.1f%%\" % (matches.sum(), len(matches), 100*matches.sum()/float(len(matches))))"
-      ],
-      "metadata": {
-        "id": "K9nCZ5D6groz",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
-      "metadata": {
-        "id": "EgIqtl7Yn2oU",
-        "cellView": "form"
-      },
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "EgIqtl7Yn2oU"
+      },
+      "outputs": [],
       "source": [
         "#@title 反復試行による性能評価（時間がかかります）\n",
         "\n",
@@ -277,16 +265,16 @@
         "\n",
         "print(u\"Accuracy = %2.1f\\u00B1%2.1f%% [%2.1f%%, %2.1f%%]\" \n",
         "      % (accuracy.mean()*100, accuracy.std()*100, accuracy.min()*100, accuracy.max()*100))\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
-      "metadata": {
-        "id": "bRUeztQpn2op",
-        "cellView": "form"
-      },
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "bRUeztQpn2op"
+      },
+      "outputs": [],
       "source": [
         "#@title 混同行列（行：正解，列：予測）\n",
         "from sklearn import metrics\n",
@@ -296,21 +284,22 @@
         "print(cm)\n",
         "\n",
         "#print(cm.sum(axis=0)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "--------"
-      ],
       "metadata": {
         "id": "h4Xq7nKCMeqN"
-      }
+      },
+      "source": [
+        "--------"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "qFMWVuCjsNG4"
+      },
       "source": [
         "## 発展課題\n",
         "\n",
@@ -325,13 +314,15 @@
         "```\n",
         "のように使うことを想定します．\n",
         "MNISTで訓練データが1000個の場合，`X_train` と `y_train` はそれぞれ shape が (1000,784) と (1000,) のNumPy配列です．"
-      ],
-      "metadata": {
-        "id": "qFMWVuCjsNG4"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ySO1HTYEwqOG"
+      },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "from collections import Counter\n",
@@ -376,15 +367,15 @@
         "        pred = Counter(k_neighbor_labels).most_common(1)[0][0]\n",
         "\n",
         "        return pred"
-      ],
-      "metadata": {
-        "id": "ySO1HTYEwqOG"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "64N_WITlw8yd"
+      },
+      "outputs": [],
       "source": [
         "# 自作の k-NN 識別器 myclf を生成する．\n",
         "# instanciate my own kNN classifier\n",
@@ -414,21 +405,40 @@
         "# the number of correct matches / the total number of data points\n",
         "matches = (y_pred == y_val)\n",
         "print(\"Accuracy = %d / %d = %2.1f%%\" % (matches.sum(), len(matches), 100*matches.sum()/float(len(matches))))"
-      ],
-      "metadata": {
-        "id": "64N_WITlw8yd"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "お疲れさまでした．"
-      ],
       "metadata": {
         "id": "-svKKyHE-Vcl"
-      }
+      },
+      "source": [
+        "お疲れさまでした．"
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.6"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
[MNISTのk近傍識別のノートブック](ipynb/ex_MNIST_knn_classification.ipynb)で，ソースに雑音付加したデータは，最後に*雑音したもの* に $\[0, 255\]$ にクリップしているのかなと思います．よって対象はXimages_allではなくXimagesかなと．